### PR TITLE
Update age requirement to 15 and older

### DIFF
--- a/src/components/ProgramSection.tsx
+++ b/src/components/ProgramSection.tsx
@@ -7,7 +7,7 @@ export default function ProgramSection() {
     {
       icon: '👥',
       title: 'Doelgroep',
-      description: 'Volwassenen vanaf 15 jaar',
+      description: '15 jaar en ouder',
     },
     {
       icon: '📊',

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -54,7 +54,7 @@ test.describe('ZWEM.COACH Homepage', () => {
   })
 
   test('should display program information correctly', async ({ page }) => {
-    await expect(page.getByText(/Volwassenen vanaf 15 jaar/i)).toBeVisible()
+    await expect(page.getByText(/15 jaar en ouder/i)).toBeVisible()
     await expect(
       page.getByText(/Maximaal 15 personen per groep/i)
     ).toBeVisible()


### PR DESCRIPTION
Changed from 'Volwassenen vanaf 15 jaar' to '15 jaar en ouder' for clearer communication of the target age group, as 15-year-olds are not technically adults.