### PR TITLE
Add scroll indicator to hero section

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -127,6 +127,26 @@ export default function HeroSection() {
           </motion.div>
         </div>
       </div>
+
+      {/* Scroll Indicator */}
+      <motion.div
+        className="absolute bottom-8 left-1/2 transform -translate-x-1/2 z-10"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.5, duration: 0.5 }}
+      >
+        <motion.div
+          className="w-6 h-10 border-2 border-white/60 rounded-full flex justify-center"
+          animate={{ y: [0, 5, 0] }}
+          transition={{ duration: 2, repeat: Infinity }}
+        >
+          <motion.div
+            className="w-1 h-3 bg-white/60 rounded-full mt-2"
+            animate={{ y: [0, 12, 0] }}
+            transition={{ duration: 2, repeat: Infinity }}
+          />
+        </motion.div>
+      </motion.div>
     </section>
   )
 }


### PR DESCRIPTION
Added an animated scroll indicator at the bottom of the hero section using Framer Motion. The indicator features a mouse-like design with a bouncing dot animation that fades in after 1.5 seconds and continuously animates to encourage users to scroll down.