### PR TITLE
Fix header capitalization: change 'Crawl' to 'crawl'

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -110,7 +110,7 @@ export default function HeroSection() {
                 />
               </div>
               <span className="text-3xl md:text-5xl lg:text-7xl text-athletic-accent block break-words">
-                Technieklessen Crawl Vilvoorde
+                Technieklessen crawl Vilvoorde
               </span>
             </h1>
 


### PR DESCRIPTION
Resolves #26 by updating the HeroSection header text from 'Technieklessen Crawl Vilvoorde' to 'Technieklessen crawl Vilvoorde'