### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/WP-Coaching/zwem.coach/security/code-scanning/1](https://github.com/WP-Coaching/zwem.coach/security/code-scanning/1)

In general, the fix is to define a `permissions` block either at the root of the workflow or inside the specific job so that the `GITHUB_TOKEN` has only the scopes needed. For this workflow, the steps perform read-only operations on the repository (checkout, installing dependencies, running tests) plus uploading an artifact, which uses a separate token handled by `actions/upload-artifact` and does not require repository write permissions. Thus, the minimal safe permission set is `contents: read`.

The best fix without changing functionality is to add a `permissions` block at the workflow root, just below the `name:` line, so that it applies to all jobs by default. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Tests`). No additional methods, imports, or definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
