### PR TITLE
Add one-off open water training registration section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ NEXT_PUBLIC_STRIPE_SUMMERSCHOOL_INDOOR_G1_LINK=https://buy.stripe.com/your-summe
 NEXT_PUBLIC_STRIPE_SUMMERSCHOOL_INDOOR_G2_LINK=https://buy.stripe.com/your-summerschool-indoor-g2-link
 NEXT_PUBLIC_STRIPE_SUMMERSCHOOL_OPENWATER_G1_LINK=https://buy.stripe.com/your-summerschool-openwater-g1-link
 NEXT_PUBLIC_STRIPE_SUMMERSCHOOL_OPENWATER_G2_LINK=https://buy.stripe.com/your-summerschool-openwater-g2-link
+
+# One-off open water training
+NEXT_PUBLIC_STRIPE_OPEN_WATER_TRAINING_LINK=https://buy.stripe.com/bJe7sL596alEa9J4sC3F60C

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
         'https://buy.stripe.com/your-monday-link',
       NEXT_PUBLIC_STRIPE_SEPT_NOV_WEDNESDAY_LINK:
         'https://buy.stripe.com/your-wednesday-link',
+      NEXT_PUBLIC_STRIPE_OPEN_WATER_TRAINING_LINK:
+        'https://buy.stripe.com/bJe7sL596alEa9J4sC3F60C',
     },
   },
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import HeroSection from '@/components/HeroSection'
 import SummerSchoolSection from '@/components/SummerSchoolSection'
+import OpenWaterTrainingSection from '@/components/OpenWaterTrainingSection'
 import ProgramSection from '@/components/ProgramSection'
 import CoachesSection from '@/components/CoachesSection'
 import ScheduleSection from '@/components/ScheduleSection'
@@ -12,6 +13,7 @@ export default function Home() {
       <HeroSection />
       <CoachesSection />
       <SummerSchoolSection />
+      <OpenWaterTrainingSection />
       <ProgramSection />
       <ScheduleSection />
       <PricingSection />

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -14,6 +14,11 @@ export default function CTAButton() {
       detail: 'Vanaf september 2026',
       target: 'courses',
     },
+    {
+      label: 'Open water training',
+      detail: '26 augustus · 19u',
+      target: 'open-water-training',
+    },
   ]
 
   return (

--- a/src/components/OpenWaterTrainingSection.tsx
+++ b/src/components/OpenWaterTrainingSection.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+const registrationLink =
+  process.env.NEXT_PUBLIC_STRIPE_OPEN_WATER_TRAINING_LINK
+const locationLink =
+  'https://www.google.com/maps/search/?api=1&query=Sport+Vlaanderen+Willebroek+-+Hazewinkel'
+
+const equipment = [
+  'Wetsuit',
+  'Brilletje',
+  'Safety Buoy (op aanvraag bij ons te verkrijgen)',
+]
+
+export default function OpenWaterTrainingSection() {
+  return (
+    <section
+      id="open-water-training"
+      aria-labelledby="open-water-training-title"
+      className="relative overflow-hidden bg-athletic-dark py-20 text-white"
+    >
+      <div
+        aria-hidden="true"
+        className="absolute -left-24 top-16 h-72 w-72 rounded-full bg-ocean-700/40 blur-3xl"
+      />
+      <div
+        aria-hidden="true"
+        className="absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-athletic-accent/20 blur-3xl"
+      />
+
+      <div className="container relative z-10 mx-auto px-4">
+        <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+          <motion.div
+            initial={{ opacity: 0, translateX: -20 }}
+            whileInView={{ opacity: 1, translateX: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            <div className="mb-5 inline-block rounded-full bg-athletic-accent px-4 py-1 text-sm font-bold uppercase tracking-wider text-athletic-dark">
+              Eenmalige training
+            </div>
+            <h2
+              id="open-water-training-title"
+              className="mb-6 font-display text-4xl font-bold md:text-5xl"
+            >
+              Open water training
+            </h2>
+            <p className="max-w-2xl text-xl leading-relaxed text-gray-200">
+              Bereid je voor op je volgende openwateruitdaging tijdens een
+              gerichte training in Hazewinkel.
+            </p>
+
+            <div className="mt-8 grid gap-4 sm:grid-cols-3">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wider text-ocean-300">
+                  Wanneer
+                </p>
+                <p className="mt-1 text-lg font-semibold">
+                  Woensdag 26 augustus
+                </p>
+                <p className="text-gray-300">19u00</p>
+              </div>
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wider text-ocean-300">
+                  Waar
+                </p>
+                <a
+                  href={locationLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-1 inline-block text-lg font-semibold underline decoration-ocean-400 underline-offset-4 transition-colors hover:text-ocean-300"
+                >
+                  Hazewinkel Willebroek
+                </a>
+              </div>
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-wider text-ocean-300">
+                  Prijs
+                </p>
+                <p className="mt-1 text-lg font-semibold">€30</p>
+                <p className="text-gray-300">incl. btw</p>
+              </div>
+            </div>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, translateY: 20 }}
+            whileInView={{ opacity: 1, translateY: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, delay: 0.15 }}
+            className="rounded-2xl border border-white/10 bg-white p-8 text-athletic-dark shadow-2xl"
+          >
+            <h3 className="mb-5 border-b border-gray-200 pb-3 font-display text-2xl font-bold">
+              Benodigdheden
+            </h3>
+            <ul className="space-y-3 text-gray-700">
+              {equipment.map((item) => (
+                <li key={item} className="flex items-start gap-3">
+                  <span
+                    aria-hidden="true"
+                    className="mt-1 text-xl leading-none text-athletic-accent"
+                  >
+                    •
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            {registrationLink ? (
+              <a
+                href={registrationLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-8 block w-full rounded-lg bg-gradient-ocean px-4 py-3 text-center font-display font-semibold text-white shadow-ocean transition-all duration-300 hover:scale-105 hover:shadow-athletic"
+              >
+                Inschrijven voor €30
+              </a>
+            ) : (
+              <div className="mt-8 block w-full rounded-lg bg-gray-100 px-4 py-3 text-center font-display font-semibold text-gray-500">
+                Inschrijven binnenkort beschikbaar
+              </div>
+            )}
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -19,12 +19,15 @@ test.describe('zwem.coach Homepage', () => {
     ).toBeVisible()
   })
 
-  test('should have two registration CTAs in the hero section', async ({ page }) => {
+  test('should have registration CTAs in the hero section', async ({ page }) => {
     await expect(
       page.getByRole('button', { name: /Summer School.*10 - 14 augustus/i })
     ).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Lessenreeks.*Vanaf september 2026/i })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /Open water training.*26 augustus.*19u/i })
     ).toBeVisible()
   })
 
@@ -55,6 +58,24 @@ test.describe('zwem.coach Homepage', () => {
       page.getByRole('heading', { name: /Benodigdheden/i }).first()
     ).toBeVisible()
     await expect(page.getByText(/€280/i)).toBeVisible()
+  })
+
+  test('should display the open water training event', async ({ page }) => {
+    const event = page.locator('#open-water-training')
+
+    await expect(
+      event.getByRole('heading', { name: /Open water training/i })
+    ).toBeVisible()
+    await expect(event.getByText(/Woensdag 26 augustus/i)).toBeVisible()
+    await expect(event.getByText('19u00')).toBeVisible()
+    await expect(event.getByText(/Hazewinkel Willebroek/i)).toBeVisible()
+    await expect(event.getByText('€30', { exact: true })).toBeVisible()
+    await expect(event.getByText(/Wetsuit/i)).toBeVisible()
+    await expect(event.getByText(/Brilletje/i)).toBeVisible()
+    await expect(event.getByText(/Safety Buoy/i)).toBeVisible()
+    await expect(
+      event.getByRole('link', { name: /Inschrijven voor €30/i })
+    ).toHaveAttribute('href', 'https://buy.stripe.com/bJe7sL596alEa9J4sC3F60C')
   })
 
   test('should display program information correctly', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add a dedicated open water training section for the 26 August session in Hazewinkel.
- Include event details, equipment requirements, location link, and Stripe registration CTA.
- Add the event to the homepage CTA navigation and configure its registration URL.
- Extend homepage Playwright coverage for the new event and CTA.

## Testing

- Added Playwright assertions covering the CTA, event details, equipment, and Stripe link.
- Existing test suite was not run (not requested).